### PR TITLE
Add pages to default search post types

### DIFF
--- a/includes/class-post-type-petition.php
+++ b/includes/class-post-type-petition.php
@@ -187,7 +187,7 @@ class Post_Type_Petition {
 			return;
 		}
 
-		$types = $query->get( 'post_type' ) ? (array) $query->get( 'post_type' ) : [ 'post' ];
+		$types = $query->get( 'post_type' ) ? (array) $query->get( 'post_type' ) : [ 'page', 'post' ];
 		$types = $this->list_query_post_types( $types );
 
 		$query->set( 'post_type', $types );


### PR DESCRIPTION
Ref https://github.com/amnestywebsite/amnesty-wp-theme/issues/2488

**Steps to test**:
1. create and publish a page titled something unique, such as "foobarbazqux"
2. create and publish a post with the same title
3. whilst on `main`, go to `/search/`
4. perform a search for your title
5. you should only see the post in the results
6. switch to this PR
7. reload the search results page
8. you should see both the post and the page in the search results