### PR TITLE
Add support for raw HTML petitions

### DIFF
--- a/includes/class-register-block.php
+++ b/includes/class-register-block.php
@@ -106,6 +106,7 @@ class Register_Block {
 					'form'   => __( 'Form', 'aip' ),
 					/* translators: [admin] */
 					'iframe' => __( 'Iframe', 'aip' ),
+					'html'   => 'HTML',
 				],
 			]
 		);
@@ -133,6 +134,7 @@ class Register_Block {
 			'locale'       => str_replace( '_', '-', get_locale() ),
 			'defaultType'  => $this->default_block_type(),
 			'formEnabled'  => $this->form_enabled(),
+			'htmlEnabled'  => current_user_can( 'unfiltered_html' ),
 			'postTypeSlug' => esc_js( get_option( 'aip_petition_slug' ) ?: 'petition' ),
 		];
 
@@ -178,14 +180,14 @@ class Register_Block {
 		);
 
 		$render_type = $attributes['petitionSource'];
-		if ( ! in_array( $render_type, [ 'form', 'iframe' ], true ) ) {
+		if ( ! in_array( $render_type, [ 'form', 'html', 'iframe' ], true ) ) {
 			$render_type = $this->default_block_type();
 		}
 
 		$template = sprintf( '%s/views/block-%s.php', dirname( Init::$file ), $render_type );
 		$template = apply_filters( 'amnesty_petition_view', $template, $render_type );
 
-		if ( 'iframe' === $render_type ) {
+		if ( 'form' !== $render_type ) {
 			ob_start();
 			require $template;
 			return apply_filters( 'amnesty_petition_view_markup', ob_get_clean(), $render_type );
@@ -287,6 +289,7 @@ class Register_Block {
 			'iframeUrl'                  => $this->string(),
 			'iframeHeight'               => $this->int(),
 			'passUtmParameters'          => $this->bool( false ),
+			'rawHtml'                    => $this->string(),
 		];
 
 		return $this->attributes;

--- a/private/src/editor.scss
+++ b/private/src/editor.scss
@@ -153,3 +153,24 @@
 .wp-block-amnesty-petition .petition-form-iframe input {
   color: #000;
 }
+
+.wp-block-amnesty-petition.is-html {
+  padding: 0;
+  border: 1px solid #000;
+  width: 400px;
+  max-width: 100%;
+}
+
+.wp-block-amnesty-petition.is-html textarea {
+  max-height: 100%;
+  overflow-y: scroll;
+  padding: 4px;
+  font-family: 'Courier New', Courier, monospace;
+  font-weight: initial;
+  text-transform: unset;
+}
+
+.wp-block-amnesty-petition.is-html iframe {
+  display: block;
+  height: 100%;
+}

--- a/private/src/editor/blocks/petition/DisplayComponent.jsx
+++ b/private/src/editor/blocks/petition/DisplayComponent.jsx
@@ -21,9 +21,16 @@ export default class DisplayComponent extends Component {
 
   htmlIframeResizeHandler = (message) => {
     if (message?.data?.action === 'resize') {
+      const height = Math.max(
+        message.data.height,
+        parseFloat(message.source.frameElement.getAttribute('height')),
+        parseFloat(message.source.document.documentElement.getBoundingClientRect().height),
+        200, // default min-height
+      );
+
       this.setState({
         htmlIframeStyles: {
-          height: `${message.source.document.documentElement.getBoundingClientRect().height}px`,
+          height: `${Math.ceil(height)}px`,
         },
       });
     }

--- a/private/src/editor/blocks/petition/HtmlSource.jsx
+++ b/private/src/editor/blocks/petition/HtmlSource.jsx
@@ -1,0 +1,36 @@
+const { BlockControls, PlainText } = wp.blockEditor;
+const { ToolbarButton, ToolbarGroup } = wp.components;
+const { useState } = wp.element;
+const { __ } = wp.i18n;
+
+import Preview from './Preview.jsx';
+
+export default function HtmlSource({ content, isSelected, setContent, userCanEdit }) {
+  const [isPreview, setIsPreview] = useState(!!content || !userCanEdit);
+
+  return (
+    <>
+			<BlockControls>
+				<ToolbarGroup>
+					{userCanEdit && (
+            <ToolbarButton isPressed={!isPreview} onClick={() => setIsPreview(false)}>
+						  HTML
+            </ToolbarButton>
+          )}
+					<ToolbarButton isPressed={isPreview} onClick={() => setIsPreview(true)}>
+						{__('Preview', 'default')}
+					</ToolbarButton>
+				</ToolbarGroup>
+			</BlockControls>
+      {isPreview && <Preview content={content} isSelected={isSelected} />}
+      {!isPreview && (
+        <PlainText
+          value={content}
+          onChange={setContent}
+          placeholder={__('Write HTML…', 'default')}
+          aria-label="HTML"
+        />
+      )}
+    </>
+  );
+}

--- a/private/src/editor/blocks/petition/Preview.jsx
+++ b/private/src/editor/blocks/petition/Preview.jsx
@@ -1,0 +1,43 @@
+const { transformStyles, store: blockEditorStore } = wp.blockEditor;
+const { SandBox } = wp.components;
+const { useSelect } = wp.data;
+const { useMemo } = wp.element;
+const { __ } = wp.i18n;
+
+// Default styles used to unset some of the styles
+// that might be inherited from the editor style.
+const DEFAULT_STYLES = `
+	html,body,:root {
+		margin: 0 !important;
+		padding: 0 !important;
+		overflow: visible !important;
+		min-height: auto !important;
+	}
+`;
+
+export default function Preview({ content, isSelected }) {
+	const settingStyles = useSelect(
+		(select) => select(blockEditorStore.name).getSettings().styles,
+		[],
+	);
+
+	const styles = useMemo(
+		() => [
+			DEFAULT_STYLES,
+			...transformStyles((settingStyles ?? []).filter((style) => style.css)),
+		],
+		[settingStyles],
+	);
+
+	return (
+		<>
+			<SandBox
+				html={content}
+				styles={styles}
+				title={__('Custom HTML Preview', 'default')}
+				tabIndex={-1}
+			/>
+			{!isSelected && <div className="block-library-html__preview-overlay"></div>}
+		</>
+	);
+}

--- a/private/src/editor/blocks/petition/index.jsx
+++ b/private/src/editor/blocks/petition/index.jsx
@@ -2,6 +2,7 @@ import DisplayComponent from './DisplayComponent.jsx';
 
 const { assign } = lodash;
 const { registerBlockType } = wp.blocks;
+const { RawHTML } = wp.element;
 const { __ } = wp.i18n;
 
 const strType = {
@@ -67,6 +68,7 @@ registerBlockType('amnesty/petition', {
     iframeUrl: strType,
     iframeHeight: intType,
     passUtmParameters: boolTypeFalse,
+    rawHtml: strType,
   },
   edit: DisplayComponent,
   save: () => null,

--- a/views/block-html.php
+++ b/views/block-html.php
@@ -1,0 +1,5 @@
+<?php
+
+// this attribute can only be edited by users with the `unfiltered_html` capability
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo $attributes['rawHtml'];


### PR DESCRIPTION
Ref https://github.com/amnestywebsite/humanity-petitions/issues/17

**Steps to test:**
1. log in as an Editor
2. create a new petition
3. you should not have the option to change the petition type to "HTML"
4. log in as an administrator/super-admin
5. create a new petition
6. you should be able to change the petition type to "HTML"
7. you should be able to insert arbitrary HTML into the petition, and save it
8. clicking "Preview" whilst you have the petition selected should allow you to preview your HTML
9. preview the petition
10. your HTML should be output on the frontend in the usual petition location
11. in Network Admin -> Network Options, you should be able to set the default petition type to "HTML". do so
12. create a new petition
13. the petition type should be pre-set to "HTML"
14. log in as an Editor
15. edit the petition you created in step 7
16. the petition should render correctly
17. you should not be able to de-select preview mode on the petition
18. preview the petition
19. the petition should render correctly