### PR TITLE
Load text domain later

### DIFF
--- a/amnesty-petitions.php
+++ b/amnesty-petitions.php
@@ -90,13 +90,11 @@ class Init {
 	 * Bind hooks and instantiate pages
 	 */
 	public function __construct() {
-		$this->data = get_plugin_data( __FILE__ );
-
 		add_filter( 'register_translatable_package', [ $this, 'register_translatable_package' ], 12 );
 
 		add_action( 'all_admin_notices', [ $this, 'check_dependencies' ] );
 
-		add_action( 'plugins_loaded', [ $this, 'textdomain' ] );
+		add_action( 'init', [ $this, 'textdomain' ] );
 		add_action( 'init', [ $this, 'boot' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 
@@ -160,6 +158,8 @@ class Init {
 	 * @return void
 	 */
 	public function boot(): void {
+		$this->data = get_plugin_data( __FILE__ );
+
 		new Post_Type_Petition();
 		new Post_Type_Signatory();
 		new Petition_Handler( $this::get_logger(), Error_Handler::instance() );


### PR DESCRIPTION
Fixes #23

steps to test:
- before checkout
- be on wp 6.7
- make sure the plugin is active
- install and activate query monitor
- view the site
- see the deprecation notice from WP Core
- checkout this pr
- reload the site
- the deprecation notice should disappear
- the plugin should still function correctly
- the aip text domain should still load correctly (check via query monitor on non-EN)